### PR TITLE
Add conf cancelled text

### DIFF
--- a/components/Banner.js
+++ b/components/Banner.js
@@ -4,15 +4,11 @@ import styled from 'styled-components';
 import { data } from '../data/data';
 import {
   Header as HeaderPrimitive,
+  HeaderAccent,
   Paragraph,
   ParagraphAccent,
-  ParagraphXSmall,
-  ParagraphXSmallAccent,
-  ParagraphInverted,
 } from './Typography';
 import { Logo } from './Logo';
-import { SectionWrapper } from './SectionWrapper';
-import { PrimaryCTA, GreenCTA } from './Buttons';
 
 const BannerWrapper = styled.section`
   display: grid;
@@ -26,18 +22,6 @@ const ImageWrapper = styled.div`
   margin-top: 10px;
 `;
 
-const CTAWrapper = styled.div`
-  display: grid;
-  justify-items: center;
-  grid-row-gap: 15px;
-  margin-top: 20px;
-
-  @media (min-width: 768px) {
-    margin-top: 30px;
-    grid-template-columns: 1fr;
-    grid-column-gap: 30px;
-  }
-`;
 
 const Header = styled(HeaderPrimitive)`
   padding-left: 15px;
@@ -61,21 +45,15 @@ export function Banner() {
           for Spanish speakers{' '}
           <ParagraphAccent as="span">in Latin America</ParagraphAccent>
         </HeaderSubtitle>
-        <ParagraphInverted>Medellín, July 18, 2020</ParagraphInverted>
         <ImageWrapper>
           <Logo width={128} />
         </ImageWrapper>
-        <ParagraphXSmall>
-          Complejo Ruta N Calle 67 Nº 52-20
-          <br /> Piso 2 Torre A. Medellín - Colombia
-        </ParagraphXSmall>
+        <Header>
+          React La Conf has been{' '}
+          <HeaderAccent as="span">cancelled</HeaderAccent>, See you next
+          year!
+        </Header>
       </BannerWrapper>
-      <SectionWrapper>
-        <CTAWrapper>
-          <GreenCTA href={data.links.cfp}>call for speakers</GreenCTA>
-          <PrimaryCTA href={data.links.tickets}>ReactLaConf tickets</PrimaryCTA>
-        </CTAWrapper>
-      </SectionWrapper>
     </>
   );
 }

--- a/components/Typography.js
+++ b/components/Typography.js
@@ -15,6 +15,10 @@ export const Header = styled.h2`
   font-weight: 900;
 `;
 
+export const HeaderAccent = styled(Header)`
+  color: ${props => props.theme.text.accent};
+`;
+
 export const HeaderLarge = styled.h2`
   color: ${props => props.theme.text.primary};
   font-size: 48px;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,20 +1,10 @@
 import React from 'react';
-import Head from 'next/head';
 import { Navigation } from '../components/Navigation/Navigation';
 import { Banner } from '../components/Banner';
-import { Section, SectionInverted } from '../components/Sections';
-import { Numbers } from '../components/Numbers';
 import { data } from '../data/data';
-import { GetHere } from '../components/GetHere';
 import { AboutUs } from '../components/AboutUs';
-import { Sponsors } from '../components/Sponsors';
-import { Venue } from '../components/Venue';
 import { Team } from '../components/Team';
-import { Speakers } from '../components/Speakers';
-import { Community } from '../components/Community';
-import { AboutMedellin } from '../components/AboutMedellin';
 import { Footer } from '../components/Footer';
-import { CodeOfConduct } from '../components/CodeOfConduct';
 
 const Home = () => (
   <div>
@@ -23,18 +13,6 @@ const Home = () => (
     <div style={{ marginTop: 30 }}>
       <AboutUs title={data.about.title}>{data.about.content}</AboutUs>
     </div>
-    <Numbers cfpHref={data.links.cfp} content={data.numbers.content} />
-    <Sponsors
-      title={data.sponsors.title}
-      companies={data.sponsors.companies}
-      cta={data.links.sponsors}
-    >
-      {data.sponsors.content}
-    </Sponsors>
-    <Speakers title={data.speakers.title} people={data.speakers.people}>
-      {data.speakers.content}
-    </Speakers>
-    <Venue title={data.venue.title}>{data.venue.content}</Venue>
     <Team
       title={data.team.title}
       people={data.team.people}
@@ -42,14 +20,6 @@ const Home = () => (
     >
       {data.team.content}
     </Team>
-    <Community
-      title={data.community.title}
-      partners={data.community.partners}
-      href={data.links.community}
-    >
-      {data.community.content}
-    </Community>
-    <AboutMedellin />
     <Footer />
   </div>
 );


### PR DESCRIPTION
# Cancelled Conf 

This PR removes the main sections of the index page, leaving only the about us, team, and footer sections.

Add the text referring to cancellation in the header of the page

**Preview**
![Screen Shot 2020-05-11 at 12 19 58](https://user-images.githubusercontent.com/23706543/81591911-c9451200-9382-11ea-8800-de99d087d5a9.png)
